### PR TITLE
Upload fix

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,7 +4,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="PLATFORM" />
+        <compositeConfiguration>
+          <compositeBuild compositeDefinitionSource="SCRIPT" />
+        </compositeConfiguration>
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -14,6 +16,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="testRunner" value="PLATFORM" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
         applicationId "nz.org.cacophony.birdmonitor"
         minSdkVersion project.ext.minimumSdkVersion
         targetSdkVersion 28
-        versionCode 150010708   
+        versionCode 150010708
         //minimumSdkVersion * 10000000 + versionMajor * 10000 + versionMinor * 100 + versionPatch
         versionName "1.7.8"
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/InstallService.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/InstallService.java
@@ -102,10 +102,10 @@ public class InstallService extends Service {
                     Crashlytics.logException(e);
                 } finally {
                     if (Util.isAirplaneModeOn(getApplicationContext())) {
-                        if ( prefs.canActiveFlightMode(Prefs.FLIGHT_MODE_PENDING_UPDATE)){
+                        if (prefs.canActiveFlightMode(Prefs.FLIGHT_MODE_PENDING_UPDATE)) {
                             Util.enableFlightMode(getApplicationContext());
                         }
-                    }else{
+                    } else {
                         prefs.setInternetRequired(false, Prefs.FLIGHT_MODE_PENDING_UPDATE);
                     }
                     stopSelf();

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/InstallService.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/InstallService.java
@@ -88,7 +88,7 @@ public class InstallService extends Service {
                     }
 
                     Prefs prefs = new Prefs(getApplicationContext());
-                    if (prefs.getFlightModePending()) {
+                    if (prefs.canActiveFlightMode(Prefs.FLIGHT_MODE_PENDING_UPDATE)) {
                         Util.enableFlightMode(getApplicationContext());
                     }
                     privService.installPackage(Uri.parse(updateURL), Prefs.ACTION_INSTALL_REPLACE_EXISTING,
@@ -101,6 +101,13 @@ public class InstallService extends Service {
                     Log.e(TAG, "RemoteException", e);
                     Crashlytics.logException(e);
                 } finally {
+                    if (Util.isAirplaneModeOn(getApplicationContext())) {
+                        if ( prefs.canActiveFlightMode(Prefs.FLIGHT_MODE_PENDING_UPDATE)){
+                            Util.enableFlightMode(getApplicationContext());
+                        }
+                    }else{
+                        prefs.setInternetRequired(false, Prefs.FLIGHT_MODE_PENDING_UPDATE);
+                    }
                     stopSelf();
                     if (wakeLock.isHeld()) {
                         wakeLock.release();

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/InstallService.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/InstallService.java
@@ -101,12 +101,8 @@ public class InstallService extends Service {
                     Log.e(TAG, "RemoteException", e);
                     Crashlytics.logException(e);
                 } finally {
-                    if (prefs.getAeroplaneMode() && !Util.isAirplaneModeOn(getApplicationContext())) {
-                        if (prefs.canActiveFlightMode(Prefs.FLIGHT_MODE_PENDING_UPDATE)) {
-                            Util.enableFlightMode(getApplicationContext());
-                        }
-                    } else {
-                        prefs.setInternetRequired(false, Prefs.FLIGHT_MODE_PENDING_UPDATE);
+                    if (prefs.canActiveFlightMode(Prefs.FLIGHT_MODE_PENDING_UPDATE)) {
+                        Util.enableFlightMode(getApplicationContext());
                     }
                     stopSelf();
                     if (wakeLock.isHeld()) {

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/InstallService.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/InstallService.java
@@ -101,7 +101,7 @@ public class InstallService extends Service {
                     Log.e(TAG, "RemoteException", e);
                     Crashlytics.logException(e);
                 } finally {
-                    if (Util.isAirplaneModeOn(getApplicationContext())) {
+                    if (prefs.getAeroplaneMode() && !Util.isAirplaneModeOn(getApplicationContext())) {
                         if (prefs.canActiveFlightMode(Prefs.FLIGHT_MODE_PENDING_UPDATE)) {
                             Util.enableFlightMode(getApplicationContext());
                         }

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/MainService.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/MainService.java
@@ -67,7 +67,6 @@ public class MainService extends IntentService {
                 String relativeTo = bundle.getString(Prefs.RELATIVE);
                 long recordTimeSeconds = Util.getRecordingDuration(getApplicationContext(), alarmIntentType, relativeTo);
                 wakeLock.acquire(recordTimeSeconds * 1000L /*10 minutes*/);
-
                 RecordAndUpload.doRecord(getApplicationContext(), alarmIntentType, relativeTo);
                 updating = checkForUpdates(getApplicationContext());
             } else {

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/MainService.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/MainService.java
@@ -29,9 +29,8 @@ public class MainService extends IntentService {
             long lastUpdate = prefs.getDateTimeLastUpdateCheck();
             long now = new Date().getTime();
             if ((now - lastUpdate) > Prefs.TIME_BETEWEEN_UPDATES_MS) {
-                Util.disableFlightMode(context);
+                Util.disableFlightMode(context, Prefs.FLIGHT_MODE_PENDING_UPDATE);
                 prefs.setDateTimeLastUpdateCheck(now);
-                prefs.setFlightModePending(prefs.getAeroplaneMode());
                 if (Util.waitForNetworkConnection(context, true)) {
                     return UpdateUtil.updateIfAvailable(context);
                 }
@@ -75,7 +74,8 @@ public class MainService extends IntentService {
                 Log.e(TAG, "MainService bundle is null");
             }
         } finally {
-            if (updating == false) {
+            if (!updating && !UpdateUtil.isDownloading(getApplicationContext())) {
+                prefs.setInternetRequired(false, Prefs.FLIGHT_MODE_PENDING_UPDATE);
                 Util.enableFlightMode(getApplicationContext());
             }
             if (wakeLock.isHeld()) {

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
@@ -716,6 +716,10 @@ public class Prefs {
         setBoolean(USER_SIGNED_IN_KEY, userSignedIn);
     }
 
+    public boolean getDeviceRegistered() {
+        return getUserSignedIn() && getDeviceName() != null;
+    }
+
     public void setLastDeviceNameUsedForTesting(String lastDeviceNameUsedForTesting) {
         setString(LAST_DEVICE_NAME_USED_FOR_TESTING_KEY, lastDeviceNameUsedForTesting);
     }

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
@@ -48,10 +48,10 @@ public class Prefs {
     static final String UPDATE_URI = "URI";
     static final double TIME_BETEWEEN_UPDATES_MS = 1000 * 60 * 60 * 24; //1 day
     private static final String TAG = Prefs.class.getName();
-    public static final int FLIGHT_MODE_PENDING_UPDATE =0x1;
+    public static final int FLIGHT_MODE_PENDING_UPDATE = 0x1;
     public static final int FLIGHT_MODE_PENDING_UPLOAD = 0x2;
 
-    private static final String FLIGHT_MODE_PENDING =  "FLIGHT_MODE_PENDING";
+    private static final String FLIGHT_MODE_PENDING = "FLIGHT_MODE_PENDING";
     private static final String RELAUNCH_ON_UPDATE = "relaunchOnUpdate";
     private static final String AUTO_UPDATE = "autoUpdate";
     private static final String USE_AEROPLANE_MODE = "useAeroplaneMode";
@@ -83,7 +83,7 @@ public class Prefs {
     private static final String TIME_BETWEEN_FREQUENT_RECORDINGS_SECONDS_KEY = "TIME_BETWEEN_FREQUENT_RECORDINGS_SECONDS";
     private static final double TIME_BETWEEN_FREQUENT_RECORDINGS_SECONDS = 900;  //900 is 15 minutes
     private static final String TIME_BETWEEN_VERY_FREQUENT_RECORDINGS_SECONDS_KEY = "TIME_BETWEEN_VERY_FREQUENT_RECORDINGS_SECONDS";
-    private static final double TIME_BETWEEN_VERY_FREQUENT_RECORDINGS_SECONDS = 120;  //120 is two minutes, use for testing
+    private static final double TIME_BETWEEN_VERY_FREQUENT_RECORDINGS_SECONDS = 240;  //240 is 4 minutes (with 2 minute leniency), use for testing
     private static final String TIME_BETWEEN_GPS_LOCATION_UPDATES_SECONDS_KEY = "TIME_BETWEEN_GPS_LOCATION_UPDATES_SECONDS";
     private static final double TIME_BETWEEN_GPS_LOCATION_UPDATES_SECONDS = 300; // 300 is 5 minutes
     private static final int shortRecordingPause = 2;
@@ -576,7 +576,7 @@ public class Prefs {
         setBoolean(IGNORE_LOW_BATTERY_KEY, ignoreLowBattery);
     }
 
-    public boolean getOnLineMode() {
+    public boolean getOnlineMode() {
         return getBoolean(ONLINE_MODE_KEY);
     }
 
@@ -784,7 +784,7 @@ public class Prefs {
 
     public boolean canActiveFlightMode(int finishedFlags) {
         int flightPending = getFlightModePending();
-        if ((flightPending & finishedFlags) >0){
+        if ((flightPending & finishedFlags) > 0) {
             flightPending = setInternetRequired(false, finishedFlags);
             return flightPending == 0;
         }
@@ -793,12 +793,12 @@ public class Prefs {
 
     public int setInternetRequired(boolean required, int flags) {
         int flightPending = getFlightModePending();
-        if(required) {
-            flightPending |=  flags;
-        }else{
+        if (required) {
+            flightPending |= flags;
+        } else {
             flightPending &= ~flags;
         }
-        setInt(FLIGHT_MODE_PENDING,flightPending);
+        setInt(FLIGHT_MODE_PENDING, flightPending);
         return flightPending;
     }
 //

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
@@ -796,7 +796,7 @@ public class Prefs {
     }
 
     /*
-      setInternetRequired saves  what part of the app, specified by flags
+      setInternetRequired saves what part of the app, specified by flags
       is requiring internet ( keeps flight mode from being enabled by the app)
     */
     public int setInternetRequired(boolean required, int flags) {

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
@@ -782,6 +782,10 @@ public class Prefs {
     }
 
 
+    /*
+    canActivateFlightMode removes the provided flags from preventing flight mode activation
+    and then returns weather or not we can activate flight mode (nothing is requiring connection)
+    */
     public boolean canActiveFlightMode(int finishedFlags) {
         int flightPending = getFlightModePending();
         if ((flightPending & finishedFlags) > 0) {
@@ -791,6 +795,10 @@ public class Prefs {
         return false;
     }
 
+    /*
+      setInternetRequired saves  what part of the app, specified by flags
+      is requiring internet ( keeps flight mode from being enabled by the app)
+    */
     public int setInternetRequired(boolean required, int flags) {
         int flightPending = getFlightModePending();
         if (required) {
@@ -801,27 +809,6 @@ public class Prefs {
         setInt(FLIGHT_MODE_PENDING, flightPending);
         return flightPending;
     }
-//
-//    public void setFlightModeUpdatePending(boolean pendingUpdate) {
-//        int flightPending = getFlightModePending();
-//        if(pendingUpdate) {
-//            flightPending |=  FLIGHT_MODE_PENDING_UPDATE;
-//        }else{
-//            flightPending &= ~FLIGHT_MODE_PENDING_UPDATE;
-//        }
-//        setInt(FLIGHT_MODE_PENDING,flightPending);
-//        return flightPending;
-//    }
-//
-//    public void setFlightModeUploadPending(boolean pendingUpdate) {
-//        int flightPending = getFlightModePending();
-//        if(pendingUpdate) {
-//            flightPending |=  FLIGHT_MODE_PENDING_UPLOAD;
-//        }else{
-//            flightPending &= ~FLIGHT_MODE_PENDING_UPLOAD;
-//        }
-//        setInt(FLIGHT_MODE_PENDING,flightPending);
-//    }
 
     public boolean getRelaunchOnUpdate() {
         return getBoolean(RELAUNCH_ON_UPDATE);

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
@@ -793,8 +793,7 @@ public class Prefs {
     public boolean canActiveFlightMode(int finishedFlags) {
         int flightPending = getFlightModePending();
         if ((flightPending & finishedFlags) > 0) {
-            flightPending = setInternetRequired(false, finishedFlags);
-            return flightPending == 0;
+            return setInternetRequired(false, finishedFlags)  == 0;
         }
         return false;
     }

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Prefs.java
@@ -48,7 +48,10 @@ public class Prefs {
     static final String UPDATE_URI = "URI";
     static final double TIME_BETEWEEN_UPDATES_MS = 1000 * 60 * 60 * 24; //1 day
     private static final String TAG = Prefs.class.getName();
-    private static final String FLIGHT_MODE_PENDING_UPDATE = "flightModePendingUpdate";
+    public static final int FLIGHT_MODE_PENDING_UPDATE =0x1;
+    public static final int FLIGHT_MODE_PENDING_UPLOAD = 0x2;
+
+    private static final String FLIGHT_MODE_PENDING =  "FLIGHT_MODE_PENDING";
     private static final String RELAUNCH_ON_UPDATE = "relaunchOnUpdate";
     private static final String AUTO_UPDATE = "autoUpdate";
     private static final String USE_AEROPLANE_MODE = "useAeroplaneMode";
@@ -774,13 +777,51 @@ public class Prefs {
         setLong(DATE_TIME_LAST_UPDATE_CHECK, dateTimeLastUpload);
     }
 
-    public boolean getFlightModePending() {
-        return getBoolean(FLIGHT_MODE_PENDING_UPDATE);
+    public int getFlightModePending() {
+        return getInt(FLIGHT_MODE_PENDING);
     }
 
-    public void setFlightModePending(boolean pendingUpdate) {
-        setBoolean(FLIGHT_MODE_PENDING_UPDATE, pendingUpdate);
+
+    public boolean canActiveFlightMode(int finishedFlags) {
+        int flightPending = getFlightModePending();
+        if ((flightPending & finishedFlags) >0){
+            flightPending = setInternetRequired(false, finishedFlags);
+            return flightPending == 0;
+        }
+        return false;
     }
+
+    public int setInternetRequired(boolean required, int flags) {
+        int flightPending = getFlightModePending();
+        if(required) {
+            flightPending |=  flags;
+        }else{
+            flightPending &= ~flags;
+        }
+        setInt(FLIGHT_MODE_PENDING,flightPending);
+        return flightPending;
+    }
+//
+//    public void setFlightModeUpdatePending(boolean pendingUpdate) {
+//        int flightPending = getFlightModePending();
+//        if(pendingUpdate) {
+//            flightPending |=  FLIGHT_MODE_PENDING_UPDATE;
+//        }else{
+//            flightPending &= ~FLIGHT_MODE_PENDING_UPDATE;
+//        }
+//        setInt(FLIGHT_MODE_PENDING,flightPending);
+//        return flightPending;
+//    }
+//
+//    public void setFlightModeUploadPending(boolean pendingUpdate) {
+//        int flightPending = getFlightModePending();
+//        if(pendingUpdate) {
+//            flightPending |=  FLIGHT_MODE_PENDING_UPLOAD;
+//        }else{
+//            flightPending &= ~FLIGHT_MODE_PENDING_UPLOAD;
+//        }
+//        setInt(FLIGHT_MODE_PENDING,flightPending);
+//    }
 
     public boolean getRelaunchOnUpdate() {
         return getBoolean(RELAUNCH_ON_UPDATE);

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/RecordAndUpload.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/RecordAndUpload.java
@@ -78,7 +78,7 @@ public class RecordAndUpload {
 
 
         // Checked that it has a webToken before trying to upload
-        if (prefs.getToken() == null) {
+        if (!prefs.getDeviceRegistered()) {
             String messageToDisplay = "The Phone is NOT registered - could not upload the files.";
             MessageHelper.broadcastMessage(messageToDisplay, UPLOADING_FAILED_NOT_REGISTERED, MANAGE_RECORDINGS_ACTION, context);
         } else {
@@ -395,7 +395,6 @@ public class RecordAndUpload {
             boolean tokenIsCurrent = Util.isWebTokenCurrent(prefs);
 
             if ((prefs.getToken() == null) || !tokenIsCurrent) {
-
                 if (!Server.login(context)) {
                     Log.w(TAG, "sendFile: no JWT. Aborting upload");
                     return false; // Can't upload without JWT, login/register device to get JWT.

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/RecordAndUpload.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/RecordAndUpload.java
@@ -355,11 +355,12 @@ public class RecordAndUpload {
             Log.e(TAG, "Error getting recordings folder.");
             return false;
         }
+        Prefs prefs = new Prefs(context);
 
         File[] recordingFiles = recordingsFolder.listFiles();
         if (recordingFiles != null) {
 
-            Util.disableFlightMode(context);
+            Util.disableFlightMode(context, Prefs.FLIGHT_MODE_PENDING_UPLOAD);
 
             // Now wait for network connection as setFlightMode takes a while
             if (!Util.waitForNetworkConnection(context, true)) {
@@ -370,7 +371,6 @@ public class RecordAndUpload {
             // Check here to see if can connect to server and abort (for all files) if can't
             // Check that there is a JWT (JSON Web Token)
 
-            Prefs prefs = new Prefs(context);
 
             // check to see if webToken needs updating
             boolean tokenIsCurrent = Util.isWebTokenCurrent(prefs);
@@ -438,6 +438,7 @@ public class RecordAndUpload {
                     if (!isCancelUploadingRecordings()) {
                         Log.e(TAG, "Failed to upload file to server");
                     }
+                    prefs.setInternetRequired(false,Prefs.FLIGHT_MODE_PENDING_UPLOAD);
                     return false;
                 }
             }
@@ -446,6 +447,7 @@ public class RecordAndUpload {
             messageToDisplay = "Recordings have been successfully uploaded to the server.";
             MessageHelper.broadcastMessage(messageToDisplay, UPLOADING_FINISHED, MANAGE_RECORDINGS_ACTION, context);
         }
+        prefs.setInternetRequired(false,Prefs.FLIGHT_MODE_PENDING_UPLOAD);
         return returnValue;
 
     }

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Server.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Server.java
@@ -73,25 +73,6 @@ public class Server {
     private static boolean uploading = false;
     private static boolean uploadSuccess = false;
 
-//
-//    static void updateServerConnectionStatus(Context context) {
-//
-//        try {
-//            Util.disableFlightMode(context);
-//
-//            // Now wait for network connection as setFlightMode takes a while
-//            if (!Util.waitForNetworkConnection(context, true)) {
-//                Log.e(TAG, "Failed to get internet connection");
-//                return;
-//            }
-//
-//            login(context);
-//        } catch (Exception ex) {
-//            Log.e(TAG, ex.getLocalizedMessage(), ex);
-//        }
-//    }
-//
-
     public static boolean login(Context context) {
         final Prefs prefs = new Prefs(context);
         try {

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Server.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Server.java
@@ -73,24 +73,24 @@ public class Server {
     private static boolean uploading = false;
     private static boolean uploadSuccess = false;
 
-
-    static void updateServerConnectionStatus(Context context) {
-
-        try {
-            Util.disableFlightMode(context);
-
-            // Now wait for network connection as setFlightMode takes a while
-            if (!Util.waitForNetworkConnection(context, true)) {
-                Log.e(TAG, "Failed to get internet connection");
-                return;
-            }
-
-            login(context);
-        } catch (Exception ex) {
-            Log.e(TAG, ex.getLocalizedMessage(), ex);
-        }
-    }
-
+//
+//    static void updateServerConnectionStatus(Context context) {
+//
+//        try {
+//            Util.disableFlightMode(context);
+//
+//            // Now wait for network connection as setFlightMode takes a while
+//            if (!Util.waitForNetworkConnection(context, true)) {
+//                Log.e(TAG, "Failed to get internet connection");
+//                return;
+//            }
+//
+//            login(context);
+//        } catch (Exception ex) {
+//            Log.e(TAG, ex.getLocalizedMessage(), ex);
+//        }
+//    }
+//
 
     public static boolean login(Context context) {
         final Prefs prefs = new Prefs(context);

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Util.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Util.java
@@ -574,13 +574,13 @@ public class Util {
     public static void disableFlightMode(final Context context) {
         disableFlightMode(context, 0);
     }
-    
+
     public static void disableFlightMode(final Context context, int flags) {
         Prefs prefs = new Prefs(context);
         if (!prefs.getAeroplaneMode()) {
             return;
         }
-        if(flags > 0) {
+        if (flags > 0) {
             prefs.setInternetRequired(true, flags);
         }
         new Thread(() -> {
@@ -635,7 +635,7 @@ public class Util {
             return;
         }
 
-        boolean onlineMode = prefs.getOnLineMode();
+        boolean onlineMode = prefs.getOnlineMode();
 
 
         if (onlineMode) {
@@ -658,7 +658,7 @@ public class Util {
             prefs.setInternetRequired(true, Prefs.FLIGHT_MODE_PENDING_UPDATE);
             return;
         }
-        if (prefs.getFlightModePending() > 0){
+        if (prefs.getFlightModePending() > 0) {
             Log.d(TAG, "Flight mode pending status: " + prefs.getFlightModePending());
             return;
         }
@@ -936,7 +936,7 @@ public class Util {
         } else {
             wakeUpTime = System.currentTimeMillis();
             if (prefs.getUseVeryFrequentRecordings()) {
-                new Alarm((long) prefs.getTimeBetweenVeryFrequentRecordingsSeconds(), Prefs.NORMAL_URI);
+                return new Alarm(wakeUpTime + 1000 * (long) prefs.getTimeBetweenVeryFrequentRecordingsSeconds(), Prefs.NORMAL_URI);
             }
 
             float chance = new Random().nextFloat();
@@ -983,8 +983,8 @@ public class Util {
             Log.e(TAG, "alarmManager is null");
             return;
         }
-
         boolean updateTime = (triggerType != null && triggerType.equals(Prefs.REPEATING_ALARM)) || !alarmExists(context);
+
         int flags = 0;
         if (prefs.getUseSunAlarms()) {
             flags = PendingIntent.FLAG_UPDATE_CURRENT;

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Util.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Util.java
@@ -981,7 +981,6 @@ public class Util {
             return;
         }
         boolean updateTime = (triggerType != null && triggerType.equals(Prefs.REPEATING_ALARM)) || !alarmExists(context);
-
         int flags = 0;
         if (prefs.getUseSunAlarms()) {
             flags = PendingIntent.FLAG_UPDATE_CURRENT;

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Util.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Util.java
@@ -572,15 +572,22 @@ public class Util {
     }
 
     public static void disableFlightMode(final Context context) {
-        if (!new Prefs(context).getAeroplaneMode()) {
+        disableFlightMode(context, 0);
+    }
+    
+    public static void disableFlightMode(final Context context, int flags) {
+        Prefs prefs = new Prefs(context);
+        if (!prefs.getAeroplaneMode()) {
             return;
+        }
+        if(flags > 0) {
+            prefs.setInternetRequired(true, flags);
         }
         new Thread(() -> {
             try {
                 if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN) {
                     // API 17 onwards.
                     // Must be a rooted device
-                    Prefs prefs = new Prefs(context);
                     if (!prefs.getHasRootAccess()) {  // don't try to disable flight mode if phone has been rooted.
                         return;
                     }
@@ -648,11 +655,13 @@ public class Util {
 
         if (UpdateUtil.isDownloading(context)) {
             Log.d(TAG, "Flight mode pending as am downloading update");
-            prefs.setFlightModePending(true);
+            prefs.setInternetRequired(true, Prefs.FLIGHT_MODE_PENDING_UPDATE);
             return;
         }
-
-        prefs.setFlightModePending(false);
+        if (prefs.getFlightModePending() > 0){
+            Log.d(TAG, "Flight mode pending status: " + prefs.getFlightModePending());
+            return;
+        }
         new Thread(() -> {
             try {
                 if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN) { // Jelly bean is 4.1

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/Util.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/Util.java
@@ -635,11 +635,8 @@ public class Util {
             return;
         }
 
-        boolean onlineMode = prefs.getOnlineMode();
-
-
-        if (onlineMode) {
-            return; // don't try to enable airplane mode
+        if (prefs.getOnlineMode() || Util.isAirplaneModeOn(context)) {
+            return;
         }
 
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.JELLY_BEAN) { // Jelly bean is 4.1

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/views/MainActivity.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/views/MainActivity.java
@@ -15,6 +15,8 @@ import androidx.appcompat.widget.Toolbar;
 
 import nz.org.cacophony.birdmonitor.Prefs;
 import nz.org.cacophony.birdmonitor.R;
+import nz.org.cacophony.birdmonitor.RecordAndUpload;
+import nz.org.cacophony.birdmonitor.UpdateUtil;
 import nz.org.cacophony.birdmonitor.Util;
 
 
@@ -71,8 +73,8 @@ public class MainActivity extends AppCompatActivity {
             prefs.setIsFirstTimeFalse();
             prefs.setAutoUpdateAllowed();
         }
-
         final Button advancedButton = findViewById(R.id.btnAdvanced);
+        clearFlightModeFlags(prefs);
 
         if (prefs.getVeryAdvancedSettingsEnabled()) {
             advancedButton.setText(getResources().getString(R.string.very_advanced));
@@ -121,6 +123,21 @@ public class MainActivity extends AppCompatActivity {
             startActivity(new Intent(MainActivity.this, SetupWizardActivity.class));
         }
 
+    }
+
+    //  clears old internet requirement flags, if the app has crashed or something has gone wrong
+    private void clearFlightModeFlags(Prefs prefs) {
+        int flags = 0;
+        if (!RecordAndUpload.isUploading) {
+            flags &= Prefs.FLIGHT_MODE_PENDING_UPLOAD;
+            prefs.setInternetRequired(false, Prefs.FLIGHT_MODE_PENDING_UPLOAD);
+        }
+        if (!UpdateUtil.isDownloading(this.getApplicationContext())) {
+            flags &= Prefs.FLIGHT_MODE_PENDING_UPDATE;
+        }
+        if (flags > 0) {
+            prefs.setInternetRequired(false, flags);
+        }
     }
 
     @Override

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/views/ManageRecordingsFragment.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/views/ManageRecordingsFragment.java
@@ -81,6 +81,10 @@ public class ManageRecordingsFragment extends Fragment {
         return view;
     }
 
+    /*
+        toggleButtonStatus checks if we are currently uploading or recording and sets appropriate
+        buttons to be enabled/disabled
+    */
     public void toggleButtonStatus() {
         if (RecordAndUpload.isUploading) {
             btnCancel.setEnabled(true);
@@ -139,8 +143,8 @@ public class ManageRecordingsFragment extends Fragment {
             Toast.makeText(this.getContext(), R.string.upload_currently_recording, Toast.LENGTH_SHORT).show();
             return;
         }
-        Prefs prefs = new Prefs(getContext());
 
+        Prefs prefs = new Prefs(getContext());
         if (Util.isAirplaneModeOn(getContext())) {
             Util.disableFlightMode(getContext(), Prefs.FLIGHT_MODE_PENDING_UPLOAD);
         } else if (!Util.isNetworkConnected(getActivity().getApplicationContext())) {

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/views/ManageRecordingsFragment.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/views/ManageRecordingsFragment.java
@@ -75,7 +75,24 @@ public class ManageRecordingsFragment extends Fragment {
         displayOrHideGUIObjects();
 
         btnCancel.setEnabled(false);
+        if (tvMessages.getText() == "" && RecordAndUpload.isUploading) {
+            tvMessages.setText("Uploading recordings");
+        }
         return view;
+    }
+
+    public void toggleButtonStatus() {
+        if (RecordAndUpload.isUploading) {
+            btnCancel.setEnabled(true);
+            btnUploadFiles.setEnabled(false);
+        } else if (RecordAndUpload.isRecording) {
+            tvMessages.setText("Recording in Progress");
+            btnCancel.setEnabled(false);
+            btnUploadFiles.setEnabled(false);
+        } else {
+            btnCancel.setEnabled(false);
+            btnUploadFiles.setEnabled(true);
+        }
     }
 
     @Override
@@ -112,7 +129,7 @@ public class ManageRecordingsFragment extends Fragment {
             btnUploadFiles.setEnabled(false);
             btnDeleteAllRecordings.setEnabled(false);
         } else {
-            btnUploadFiles.setEnabled(true);
+            toggleButtonStatus();
             btnDeleteAllRecordings.setEnabled(true);
         }
     }
@@ -235,7 +252,14 @@ public class ManageRecordingsFragment extends Fragment {
                             tvMessages.setText(messageToDisplay);
                             break;
                         case RECORDING_DELETED:
+                        case RECORDING_STARTED:
                             displayOrHideGUIObjects();
+                            break;
+                        case RECORDING_FINISHED:
+                            displayOrHideGUIObjects();
+                            if (!RecordAndUpload.isUploading) {
+                                tvMessages.setText("");
+                            }
                             break;
                     }
                     displayOrHideGUIObjects();

--- a/app/src/main/java/nz/org/cacophony/birdmonitor/views/ManageRecordingsFragment.java
+++ b/app/src/main/java/nz/org/cacophony/birdmonitor/views/ManageRecordingsFragment.java
@@ -122,14 +122,15 @@ public class ManageRecordingsFragment extends Fragment {
             Toast.makeText(this.getContext(), R.string.upload_currently_recording, Toast.LENGTH_SHORT).show();
             return;
         }
+        Prefs prefs = new Prefs(getContext());
+
         if (Util.isAirplaneModeOn(getContext())) {
-            Util.disableFlightMode(getContext());
+            Util.disableFlightMode(getContext(), Prefs.FLIGHT_MODE_PENDING_UPLOAD);
         } else if (!Util.isNetworkConnected(getActivity().getApplicationContext())) {
             tvMessages.setText("The phone is not currently connected to the internet - please fix and try again");
             return;
         }
 
-        Prefs prefs = new Prefs(getActivity().getApplicationContext());
         if (prefs.getGroupName() == null) {
             tvMessages.setText("You need to register this phone before you can upload");
             return;


### PR DESCRIPTION
Be more specific about internal requirements of internet. Allowing us to enable flight mode only when nothing is using the internet. This fixes a problem where a manual upload could be cancelled by a scheduled recording finished.

Only allow manual uploading to be clicked once by monitoring weather or not we are currently uploading

Update Manual Recordings status when a recording starts and finishes.

Fix bug where if token refresh fails once it wont try automatically upload files again